### PR TITLE
snprintf() needs to be explicitly included

### DIFF
--- a/src/type_utilities.c
+++ b/src/type_utilities.c
@@ -15,6 +15,7 @@
 #include <micro_ros_utilities/type_utilities.h>
 
 #include <string.h>
+#include <stdio.h>
 
 #include <rosidl_typesupport_introspection_c/identifier.h>
 #include <rosidl_typesupport_introspection_c/field_types.h>


### PR DESCRIPTION
Solve a warning detected in the proces of https://github.com/micro-ROS/micro_ros_setup/issues/397