### PR TITLE
Document memory_conf_t and memory_rule_t members

### DIFF
--- a/include/micro_ros_utilities/type_utilities.h
+++ b/include/micro_ros_utilities/type_utilities.h
@@ -72,7 +72,7 @@ typedef struct micro_ros_utilities_memory_conf_t
   size_t max_basic_type_sequence_capacity;
 
   /**
-   * All ruled defined in this configuration.
+   * All rules defined in this configuration.
    *
    */
   const micro_ros_utilities_memory_rule_t * rules;

--- a/include/micro_ros_utilities/type_utilities.h
+++ b/include/micro_ros_utilities/type_utilities.h
@@ -32,18 +32,61 @@ extern "C"
 // Memory rule
 typedef struct micro_ros_utilities_memory_rule_t
 {
+  /**
+   * Pattern matching the fully qualified name of a msg field.
+   *
+   */
   const char * rule;
+
+  /**
+   * Memory (in bytes) to allocate for fields matching \ref rule.
+   *
+   */
   size_t size;
 } micro_ros_utilities_memory_rule_t;
 
 // Memory configuration string
 typedef struct micro_ros_utilities_memory_conf_t
 {
+  /**
+   * Maximum string capacity to use for msg fields in case they don't have a
+   * custom rule assigned to them.
+   *
+   */
   size_t max_string_capacity;
+
+  /**
+   * Maximum capacity to use for sequence type msg fields (ie: unbounded
+   * arrays and lists) which contain ROS 2 msg types, in case they don't have
+   * a custom rule assigned to them.
+   *
+   */
   size_t max_ros2_type_sequence_capacity;
+
+  /**
+   * Maximum capacity to use for sequence type msg fields (ie: unbounded
+   * arrays and lists) which contain basic types (ie: primitive field types),
+   * in case they don't have a custom rule assigned to them.
+   *
+   */
   size_t max_basic_type_sequence_capacity;
+
+  /**
+   * All ruled defined in this configuration.
+   *
+   */
   const micro_ros_utilities_memory_rule_t * rules;
+
+  /**
+   * Total number of rules defined in this configuration.
+   *
+   */
   size_t n_rules;
+
+  /**
+   * The allocator to use when applying this configuration.
+   *
+   */
   const rcutils_allocator_t * allocator;
 } micro_ros_utilities_memory_conf_t;
 

--- a/include/micro_ros_utilities/type_utilities.h
+++ b/include/micro_ros_utilities/type_utilities.h
@@ -39,7 +39,7 @@ typedef struct micro_ros_utilities_memory_rule_t
   const char * rule;
 
   /**
-   * Memory (in bytes) to allocate for fields matching \ref rule.
+   * Maximum string or sequence capacity for fields matching \ref rule.
    *
    */
   size_t size;


### PR DESCRIPTION
As per subject.

I've added some (very terse) documentation to the fields in `micro_ros_utilities_memory_rule_t` and `micro_ros_utilities_memory_conf_t`, as I kept having to go back to the [Handling messages memory in micro-ROS](https://micro.ros.org/docs/tutorials/advanced/handling_type_memory/) page to see what the fields are for.

Note: I'm not sure I understood the purpose of each of the fields completely -- or documented them correctly. The purpose of this PR is as much a way for me to get some confirmation.
